### PR TITLE
Adding Babel transform for native async/await.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,22 @@ Example of using Comlink to invoke services between the browser and multiple sha
 To run:
 
 ```
+npm install
 npx nx serve webapp
 ```
 
-To run Jaeger:
+To view shared workers (in Chrome):
+
+```
+chrome://inspect/#workers
+```
+
+To run [Jaeger](https://www.jaegertracing.io/) and view telemetry data:
 
 ```
 ./jaeger-all-in-one --collector.otlp.http.cors.allowed-headers=* --collector.otlp.http.cors.allowed-origins=http://localhost:4200
 ```
+
+then navigate to [http://localhost:16686](http://localhost:16686) to use the Jaeger UI.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/dfbaskin/shared-worker-service-invocation)

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@typescript-eslint/eslint-plugin": "^5.60.1",
         "@typescript-eslint/parser": "^5.60.1",
         "babel-jest": "^29.4.1",
+        "babel-plugin-transform-async-to-promises": "^0.8.18",
         "eslint": "~8.46.0",
         "eslint-config-prettier": "8.1.0",
         "eslint-plugin-import": "2.27.5",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@typescript-eslint/eslint-plugin": "^5.60.1",
     "@typescript-eslint/parser": "^5.60.1",
     "babel-jest": "^29.4.1",
+    "babel-plugin-transform-async-to-promises": "^0.8.18",
     "eslint": "~8.46.0",
     "eslint-config-prettier": "8.1.0",
     "eslint-plugin-import": "2.27.5",

--- a/pkg/definitions/src/telemetry.ts
+++ b/pkg/definitions/src/telemetry.ts
@@ -12,6 +12,7 @@ import {
   trace,
   Span,
   SpanStatusCode,
+  Attributes,
 } from '@opentelemetry/api';
 
 let provider: WebTracerProvider | undefined;
@@ -80,6 +81,8 @@ export function getCurrentSpan() {
   return wrapSpan(span);
 }
 
+export type WrappedSpan = ReturnType<typeof wrapSpan>;
+
 function wrapSpan(span: Span) {
   const endSpan = () => {
     span.end();
@@ -91,6 +94,13 @@ function wrapSpan(span: Span) {
     );
   };
 
+  const setSpanSuccess = (message?: string) => {
+    span.setStatus({
+      code: SpanStatusCode.OK,
+      message
+    });
+  };
+
   const setSpanError = (error: unknown) => {
     span.setStatus({
       code: SpanStatusCode.ERROR,
@@ -98,8 +108,8 @@ function wrapSpan(span: Span) {
     });
   };
 
-  const addSpanEvent = (name: string) => {
-    span.addEvent(name);
+  const addSpanEvent = (name: string, attributes?: Attributes) => {
+    span.addEvent(name, attributes);
   };
 
   const getSpanMetaData = () => {
@@ -112,7 +122,7 @@ function wrapSpan(span: Span) {
     return { traceparent, tracestate };
   };
 
-  return { endSpan, withSpan, addSpanEvent, setSpanError, getSpanMetaData };
+  return { endSpan, withSpan, addSpanEvent, setSpanSuccess, setSpanError, getSpanMetaData };
 }
 
 function isSpanMetaData(

--- a/pkg/service-b/src/operations.ts
+++ b/pkg/service-b/src/operations.ts
@@ -1,0 +1,25 @@
+import { createSpan } from "@example/definitions";
+
+export async function operationOne() {
+  const timeout = 1000;
+  const span = createSpan("operation-one");
+  span.addSpanEvent("Starting operation one.", {
+    timeout
+  })
+  await new Promise((resolve) => setTimeout(resolve, timeout));
+  span.setSpanSuccess("Finished operation one.");
+  span.endSpan();
+  return "operation-one";
+}
+
+export async function operationTwo() {
+  const timeout = 500;
+  const span = createSpan("operation-two");
+  span.addSpanEvent("Starting operation two.", {
+    timeout
+  })
+  await new Promise((resolve) => setTimeout(resolve, timeout));
+  span.setSpanSuccess("Finished operation two.");
+  span.endSpan();
+  return "operation-two";
+}

--- a/pkg/webapp/.babelrc
+++ b/pkg/webapp/.babelrc
@@ -7,5 +7,12 @@
       }
     ]
   ],
-  "plugins": []
+  "plugins": [
+    [
+      "babel-plugin-transform-async-to-promises",
+      {
+        "externalHelpers": true
+      }
+    ]
+  ]
 }

--- a/pkg/webapp/src/main.tsx
+++ b/pkg/webapp/src/main.tsx
@@ -8,23 +8,33 @@ initializeTelemetry({
   serviceName: 'web-app',
 });
 
-const span = createSpan('initialize');
+initialize()
+  .then(() => {
+    console.log('Initialized.');
+  })
+  .catch((error) => {
+    console.error('Failed to initialize.', error);
+  });
 
-try {
-  await connectToSharedWorkers();
-  span.addSpanEvent('Connected to shared workers.');
+async function initialize() {
+  const span = createSpan('initialize');
 
-  const root = ReactDOM.createRoot(
-    document.getElementById('root') as HTMLElement
-  );
-  root.render(
-    <StrictMode>
-      <App />
-    </StrictMode>
-  );
-  span.addSpanEvent('Rendered UI.');
-} catch (error) {
-  span.setSpanError(error);
+  try {
+    await connectToSharedWorkers();
+    span.addSpanEvent('Connected to shared workers.');
+
+    const root = ReactDOM.createRoot(
+      document.getElementById('root') as HTMLElement
+    );
+    root.render(
+      <StrictMode>
+        <App />
+      </StrictMode>
+    );
+    span.addSpanEvent('Rendered UI.');
+  } catch (error) {
+    span.setSpanError(error);
+  }
+
+  span.endSpan();
 }
-
-span.endSpan();


### PR DESCRIPTION
Zone.js does not work for native async/await so the [babel-plugin-transform-async-to-promises](https://www.npmjs.com/package/babel-plugin-transform-async-to-promises) Babel transform is required to make async operations properly collect telemetry data.