### PR TITLE
Removing zone context.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@opentelemetry/context-zone": "^1.18.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.45.1",
         "@opentelemetry/sdk-trace-base": "^1.18.1",
         "@opentelemetry/sdk-trace-web": "^1.18.1",
@@ -44,7 +43,6 @@
         "@typescript-eslint/eslint-plugin": "^5.60.1",
         "@typescript-eslint/parser": "^5.60.1",
         "babel-jest": "^29.4.1",
-        "babel-plugin-transform-async-to-promises": "^0.8.18",
         "eslint": "~8.46.0",
         "eslint-config-prettier": "8.1.0",
         "eslint-plugin-import": "2.27.5",
@@ -3420,30 +3418,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/context-zone": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.18.1.tgz",
-      "integrity": "sha512-c/y2dyqlvMPMLFZL4oDJR87ayAt4otQy9W4pddrRrNPAq1mfG9z0GrS/nvDpK7qWK0ztqzFxis4rsmCl5arW3g==",
-      "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.18.1",
-        "zone.js": "^0.11.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/context-zone-peer-dep": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.18.1.tgz",
-      "integrity": "sha512-0rqvBIW8+oMaWbVFTcEl96cpj3W3tuL4U9Mxf6PCtQctEPTGVzoFRYQ4gucYW29Ne7O2N7yit9rrrQuPja4rPA==",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "zone.js": "^0.10.2 || ^0.11.0"
       }
     },
     "node_modules/@opentelemetry/core": {
@@ -18353,14 +18327,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zone.js": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.8.tgz",
-      "integrity": "sha512-82bctBg2hKcEJ21humWIkXRlLBBmrc3nN7DFh5LGGhcyycO2S7FN8NmdvlcKaGFDNVL4/9kFLmwmInTavdJERA==",
-      "dependencies": {
-        "tslib": "^2.3.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@typescript-eslint/eslint-plugin": "^5.60.1",
     "@typescript-eslint/parser": "^5.60.1",
     "babel-jest": "^29.4.1",
-    "babel-plugin-transform-async-to-promises": "^0.8.18",
     "eslint": "~8.46.0",
     "eslint-config-prettier": "8.1.0",
     "eslint-plugin-import": "2.27.5",
@@ -47,7 +46,6 @@
     "url-loader": "^4.1.1"
   },
   "dependencies": {
-    "@opentelemetry/context-zone": "^1.18.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.45.1",
     "@opentelemetry/sdk-trace-base": "^1.18.1",
     "@opentelemetry/sdk-trace-web": "^1.18.1",

--- a/pkg/service-b/src/operations.ts
+++ b/pkg/service-b/src/operations.ts
@@ -1,8 +1,8 @@
-import { createSpan } from "@example/definitions";
+import { WrappedSpan, createSpan } from "@example/definitions";
 
-export async function operationOne() {
+export async function operationOne(parentSpan?: WrappedSpan) {
   const timeout = 1000;
-  const span = createSpan("operation-one");
+  const span = createSpan("operation-one", { parentSpan });
   span.addSpanEvent("Starting operation one.", {
     timeout
   })
@@ -12,9 +12,9 @@ export async function operationOne() {
   return "operation-one";
 }
 
-export async function operationTwo() {
+export async function operationTwo(parentSpan?: WrappedSpan) {
   const timeout = 500;
-  const span = createSpan("operation-two");
+  const span = createSpan("operation-two", { parentSpan });
   span.addSpanEvent("Starting operation two.", {
     timeout
   })

--- a/pkg/webapp/.babelrc
+++ b/pkg/webapp/.babelrc
@@ -6,13 +6,5 @@
         "runtime": "automatic"
       }
     ]
-  ],
-  "plugins": [
-    [
-      "babel-plugin-transform-async-to-promises",
-      {
-        "externalHelpers": true
-      }
-    ]
   ]
 }


### PR DESCRIPTION
Removing the `@opentelemetry/context-zone` package as well as the Babel transform that rewrites native async/await operations to promise chains.

Perhaps one of these days we'll get a real async context:
https://github.com/tc39/proposal-async-context
